### PR TITLE
feat: add frontmatter tags support to thoughts

### DIFF
--- a/app/components/Tags.tsx
+++ b/app/components/Tags.tsx
@@ -1,0 +1,30 @@
+import type React from 'react'
+import { Link } from 'react-router'
+
+type TagsProps = {
+	tags: string[]
+	className?: string
+}
+
+/**
+ * Component to display tags as clickable links
+ */
+export const Tags: React.FC<TagsProps> = ({ tags, className = '' }) => {
+	if (!tags || tags.length === 0) {
+		return null
+	}
+
+	return (
+		<div className={`flex flex-wrap gap-2 ${className}`}>
+			{tags.map((tag) => (
+				<Link
+					key={tag}
+					to={`/thoughts/tags/${encodeURIComponent(tag.toLowerCase())}`}
+					className="inline-block bg-emerald-100 dark:bg-emerald-900/30 text-emerald-800 dark:text-emerald-200 hover:bg-emerald-200 dark:hover:bg-emerald-900/50 px-2 py-1 rounded text-sm font-medium transition-colors"
+				>
+					{tag}
+				</Link>
+			))}
+		</div>
+	)
+}

--- a/app/lib/__tests__/thoughts.test.ts
+++ b/app/lib/__tests__/thoughts.test.ts
@@ -31,6 +31,14 @@ describe('thoughts library', () => {
 				expect(typeof thought.content).toBe('string')
 				expect(typeof thought.filePath).toBe('string')
 				expect(thought.dateCreated).toBeInstanceOf(Date)
+
+				// Tags are optional
+				if (thought.tags) {
+					expect(Array.isArray(thought.tags)).toBe(true)
+					for (const tag of thought.tags) {
+						expect(typeof tag).toBe('string')
+					}
+				}
 			}
 		})
 

--- a/app/lib/thoughts.ts
+++ b/app/lib/thoughts.ts
@@ -52,9 +52,15 @@ function extractMetadata(
 	// Parse frontmatter
 	const { data: frontmatter, content: markdownContent } = matter(content)
 
-	// Get file stats for creation date
-	const stats = fs.statSync(filePath)
-	const dateCreated = stats.birthtime
+	// Get date from frontmatter or file stats
+	let dateCreated: Date
+	if (frontmatter.date instanceof Date) {
+		dateCreated = frontmatter.date
+	} else {
+		// Fallback to file creation date
+		const stats = fs.statSync(filePath)
+		dateCreated = stats.birthtime
+	}
 
 	// Extract year from date
 	const year = dateCreated.getFullYear().toString()

--- a/app/routes/_index/home.tsx
+++ b/app/routes/_index/home.tsx
@@ -1,5 +1,6 @@
 import type React from 'react'
 import { Link } from 'react-router'
+import { Tags } from '~/components/Tags'
 import { formatDate } from '~/lib/date'
 import type { ThoughtPost } from '~/lib/thoughts'
 import avatar from '~/resources/img/avatar.avif'
@@ -108,6 +109,9 @@ export const Home: React.FC<HomeProps> = ({ recentThoughts }) => {
 										>
 											{formatDate(thought.dateCreated, 'short')}
 										</time>
+										{thought.tags && thought.tags.length > 0 && (
+											<Tags tags={thought.tags} className="mt-2" />
+										)}
 									</article>
 								))}
 							</div>

--- a/app/routes/thoughts.$year.$slug/route.tsx
+++ b/app/routes/thoughts.$year.$slug/route.tsx
@@ -1,4 +1,5 @@
 import { MDXContent } from '~/components/MDXContent'
+import { Tags } from '~/components/Tags'
 import { formatDate } from '~/lib/date'
 import { getAllThoughts } from '~/lib/thoughts'
 import type { Route } from './+types/route'
@@ -51,6 +52,9 @@ export default function ThoughtDetail(props: Route.ComponentProps) {
 				>
 					{formatDate(thought.dateCreated)}
 				</time>
+				{thought.tags && thought.tags.length > 0 && (
+					<Tags tags={thought.tags} className="mt-4" />
+				)}
 			</header>
 
 			<div className="max-w-none dark:text-neutral-300">

--- a/app/routes/thoughts.tags.$tag/route.tsx
+++ b/app/routes/thoughts.tags.$tag/route.tsx
@@ -1,0 +1,100 @@
+import { Link } from 'react-router'
+import { formatDate } from '~/lib/date'
+import { getAllThoughts, type ThoughtPost } from '~/lib/thoughts'
+import type { Route } from './+types/route'
+
+export function loader({ params }: Route.ClientLoaderArgs) {
+	const { tag } = params
+
+	if (!tag) {
+		throw new Response('Tag not found', { status: 404 })
+	}
+
+	const allThoughts = getAllThoughts()
+	const filteredThoughts = allThoughts.filter((thought) =>
+		thought.tags?.some((t) => t.toLowerCase() === tag.toLowerCase()),
+	)
+
+	return {
+		tag,
+		thoughts: filteredThoughts,
+	}
+}
+
+export function clientLoader({ serverLoader }: Route.ClientLoaderArgs) {
+	return serverLoader()
+}
+
+export default function TagPage({ loaderData }: Route.ComponentProps) {
+	const { tag, thoughts } = loaderData
+
+	return (
+		<div className="max-w-4xl mx-auto px-4">
+			<div className="mb-8">
+				<Link
+					to="/thoughts"
+					className="text-emerald-600 dark:text-emerald-400 hover:underline text-sm mb-4 inline-block"
+				>
+					← Back to all thoughts
+				</Link>
+				<h1 className="text-3xl font-bold text-neutral-900 dark:text-neutral-100">
+					Thoughts tagged:{' '}
+					<span className="text-emerald-600 dark:text-emerald-400">
+						{tag}
+					</span>
+				</h1>
+				<p className="text-neutral-600 dark:text-neutral-400 mt-2">
+					{thoughts.length}{' '}
+					{thoughts.length === 1 ? 'thought' : 'thoughts'} found
+				</p>
+			</div>
+
+			{thoughts.length === 0 ? (
+				<div className="text-center py-12">
+					<p className="text-neutral-500 dark:text-neutral-400">
+						No thoughts found with tag "{tag}"
+					</p>
+				</div>
+			) : (
+				<div className="space-y-6">
+					{thoughts.map((thought: ThoughtPost) => (
+						<article
+							key={`${thought.year}-${thought.slug}`}
+							className="border-b border-neutral-200 dark:border-neutral-700 pb-6 last:border-b-0"
+						>
+							<h2 className="text-xl font-semibold mb-2">
+								<Link
+									to={`/thoughts/${thought.year}/${thought.slug}`}
+									className="text-neutral-900 dark:text-neutral-100 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors"
+								>
+									{thought.title}
+								</Link>
+							</h2>
+							<time className="text-sm text-neutral-500 dark:text-neutral-400">
+								{formatDate(thought.dateCreated)}
+							</time>
+							{thought.tags && thought.tags.length > 0 && (
+								<div className="flex flex-wrap gap-2 mt-3">
+									{thought.tags.map((thoughtTag: string) => (
+										<Link
+											key={thoughtTag}
+											to={`/thoughts/tags/${encodeURIComponent(thoughtTag.toLowerCase())}`}
+											className={`inline-block px-2 py-1 rounded text-sm font-medium transition-colors ${
+												thoughtTag.toLowerCase() ===
+												tag.toLowerCase()
+													? 'bg-emerald-200 dark:bg-emerald-800 text-emerald-900 dark:text-emerald-100'
+													: 'bg-emerald-100 dark:bg-emerald-900/30 text-emerald-800 dark:text-emerald-200 hover:bg-emerald-200 dark:hover:bg-emerald-900/50'
+											}`}
+										>
+											{thoughtTag}
+										</Link>
+									))}
+								</div>
+							)}
+						</article>
+					))}
+				</div>
+			)}
+		</div>
+	)
+}

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@types/node": "^24.0.13",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
+        "gray-matter": "^4.0.3",
         "isbot": "^5.1.28",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -436,6 +437,8 @@
 
     "arg": ["arg@5.0.2", "", {}, "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="],
 
+    "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
+
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
 
     "array-flatten": ["array-flatten@1.1.1", "", {}, "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="],
@@ -634,6 +637,8 @@
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
+    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
     "estree-util-attach-comments": ["estree-util-attach-comments@3.0.0", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw=="],
 
     "estree-util-build-jsx": ["estree-util-build-jsx@3.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-walker": "^3.0.0" } }, "sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ=="],
@@ -657,6 +662,8 @@
     "express": ["express@4.21.2", "", { "dependencies": { "accepts": "~1.3.8", "array-flatten": "1.1.1", "body-parser": "1.20.3", "content-disposition": "0.5.4", "content-type": "~1.0.4", "cookie": "0.7.1", "cookie-signature": "1.0.6", "debug": "2.6.9", "depd": "2.0.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "finalhandler": "1.3.1", "fresh": "0.5.2", "http-errors": "2.0.0", "merge-descriptors": "1.0.3", "methods": "~1.1.2", "on-finished": "2.4.1", "parseurl": "~1.3.3", "path-to-regexp": "0.1.12", "proxy-addr": "~2.0.7", "qs": "6.13.0", "range-parser": "~1.2.1", "safe-buffer": "5.2.1", "send": "0.19.0", "serve-static": "1.16.2", "setprototypeof": "1.2.0", "statuses": "2.0.1", "type-is": "~1.6.18", "utils-merge": "1.0.1", "vary": "~1.1.2" } }, "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA=="],
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
+    "extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug=="],
 
     "fdir": ["fdir@6.4.6", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w=="],
 
@@ -697,6 +704,8 @@
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "gray-matter": ["gray-matter@4.0.3", "", { "dependencies": { "js-yaml": "^3.13.1", "kind-of": "^6.0.2", "section-matter": "^1.0.0", "strip-bom-string": "^1.0.0" } }, "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q=="],
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
@@ -746,6 +755,8 @@
 
     "is-decimal": ["is-decimal@2.0.1", "", {}, "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="],
 
+    "is-extendable": ["is-extendable@0.1.1", "", {}, "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="],
+
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
@@ -768,11 +779,15 @@
 
     "js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 
+    "js-yaml": ["js-yaml@3.14.1", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g=="],
+
     "jsesc": ["jsesc@3.0.2", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g=="],
 
     "json-parse-even-better-errors": ["json-parse-even-better-errors@3.0.2", "", {}, "sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
 
     "lightningcss": ["lightningcss@1.30.1", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-darwin-arm64": "1.30.1", "lightningcss-darwin-x64": "1.30.1", "lightningcss-freebsd-x64": "1.30.1", "lightningcss-linux-arm-gnueabihf": "1.30.1", "lightningcss-linux-arm64-gnu": "1.30.1", "lightningcss-linux-arm64-musl": "1.30.1", "lightningcss-linux-x64-gnu": "1.30.1", "lightningcss-linux-x64-musl": "1.30.1", "lightningcss-win32-arm64-msvc": "1.30.1", "lightningcss-win32-x64-msvc": "1.30.1" } }, "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg=="],
 
@@ -1068,6 +1083,8 @@
 
     "scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
 
+    "section-matter": ["section-matter@1.0.0", "", { "dependencies": { "extend-shallow": "^2.0.1", "kind-of": "^6.0.0" } }, "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA=="],
+
     "semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "send": ["send@0.19.0", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~1.0.2", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "0.5.2", "http-errors": "2.0.0", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "2.4.1", "range-parser": "~1.2.1", "statuses": "2.0.1" } }, "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw=="],
@@ -1114,6 +1131,8 @@
 
     "spdx-license-ids": ["spdx-license-ids@3.0.21", "", {}, "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg=="],
 
+    "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
+
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
     "statuses": ["statuses@2.0.1", "", {}, "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="],
@@ -1131,6 +1150,8 @@
     "strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
 
     "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-bom-string": ["strip-bom-string@1.0.0", "", {}, "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g=="],
 
     "strip-literal": ["strip-literal@3.0.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA=="],
 

--- a/docs/TAGS_FEATURE_PRD.md
+++ b/docs/TAGS_FEATURE_PRD.md
@@ -1,0 +1,59 @@
+# Tags Feature PRD
+
+## Goal
+Add simple tag support to thoughts feature for content organization and discovery.
+
+## User Stories
+- As a content creator, I want to add tags to my thoughts via frontmatter
+- As a reader, I want to click on tags to see related thoughts
+- As a reader, I want to see all tags on a thought page
+
+## Technical Specs
+
+### Frontmatter Format
+```yaml
+---
+tags: [javascript, react, frontend]
+---
+# My Thought Title
+Content here...
+```
+
+### URL Structure
+- Individual thought: `/thoughts/2024/my-thought/` (unchanged)
+- Tag filtering: `/thoughts/tags/javascript/` (new)
+
+### Implementation Plan
+
+#### Phase 1: Core Infrastructure
+1. **Add frontmatter parsing** - Install `gray-matter`, update `extractMetadata()`
+2. **Update types** - Add `tags?: string[]` to `ThoughtPost`
+3. **Update tests** - Verify frontmatter parsing works
+
+#### Phase 2: UI Components  
+4. **Tag display component** - Show tags as styled links on thought pages
+5. **Tag filtering page** - List all thoughts with specific tag
+6. **Update routing** - Add `/thoughts/tags/[tag]/` route
+
+#### Phase 3: Integration
+7. **Update existing thoughts** - Add frontmatter to current content (optional)
+8. **Test end-to-end** - Verify complete user flow works
+
+## Technical Decisions
+- **Library**: `gray-matter` for frontmatter parsing (industry standard)
+- **Tags format**: Array of strings in frontmatter
+- **URL encoding**: Lowercase, URL-safe tag names
+- **Fallback**: Thoughts without tags still work normally
+
+## Out of Scope
+- Tag autocomplete/suggestions
+- Tag hierarchy or categories  
+- Tag statistics/counts
+- Search functionality
+
+## Acceptance Criteria
+- [ ] Can add tags to MDX files via frontmatter
+- [ ] Tags display as clickable links on thought pages
+- [ ] Clicking tag shows list of all thoughts with that tag
+- [ ] Existing thoughts without tags continue to work
+- [ ] All existing tests pass

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 		"@types/node": "^24.0.13",
 		"@types/react": "^19.1.8",
 		"@types/react-dom": "^19.1.6",
+		"gray-matter": "^4.0.3",
 		"isbot": "^5.1.28",
 		"react": "^19.1.0",
 		"react-dom": "^19.1.0",

--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -4,11 +4,17 @@ import { distanceConfig } from './app/running/data'
 
 const thoughts = getAllThoughts()
 
+// Get all unique tags
+const allTags = new Set(
+	thoughts.flatMap(thought => thought.tags?.map(tag => tag.toLowerCase()) ?? [])
+)
+
 export const urls = [
 	'/',
 	...distanceConfig.map(({ slug }) => `/run/${slug}/`),
 	'/thoughts/',
 	...thoughts.map(({ year, slug }) => `/thoughts/${year}/${slug}/`),
+	...Array.from(allTags).map(tag => `/thoughts/tags/${encodeURIComponent(tag)}/`),
 ]
 
 export default {

--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -6,7 +6,9 @@ const thoughts = getAllThoughts()
 
 // Get all unique tags
 const allTags = new Set(
-	thoughts.flatMap(thought => thought.tags?.map(tag => tag.toLowerCase()) ?? [])
+	thoughts.flatMap(
+		(thought) => thought.tags?.map((tag) => tag.toLowerCase()) ?? [],
+	),
 )
 
 export const urls = [
@@ -14,7 +16,9 @@ export const urls = [
 	...distanceConfig.map(({ slug }) => `/run/${slug}/`),
 	'/thoughts/',
 	...thoughts.map(({ year, slug }) => `/thoughts/${year}/${slug}/`),
-	...Array.from(allTags).map(tag => `/thoughts/tags/${encodeURIComponent(tag)}/`),
+	...Array.from(allTags).map(
+		(tag) => `/thoughts/tags/${encodeURIComponent(tag)}/`,
+	),
 ]
 
 export default {


### PR DESCRIPTION
## Summary
- Add frontmatter parsing with gray-matter library
- Support tags in YAML frontmatter (e.g., `tags: [javascript, react]`)
- Add Tags component for displaying clickable tag links
- Add `/thoughts/tags/[tag]` routes for filtering thoughts by tag
- Display tags on individual thought pages and homepage
- Update prerendering to include all tag pages
- **NEW**: Add frontmatter date support to preserve chronological ordering

## Changes
- **Phase 1 (Infrastructure)**: Frontmatter parsing, type updates, tests
- **Phase 2 (UI)**: Tag components, filtering pages, homepage integration
- **Phase 3 (Date Fix)**: Frontmatter date parsing to fix sorting after adding tags
- Added tags and correct original dates to existing thoughts in submodule

## Technical Details
- `gray-matter` automatically converts YYYY-MM-DD dates to Date objects
- Uses frontmatter date if available, falls back to file creation date
- Preserves original creation dates from git history for existing posts
- All tag pages are prerendered for SSG compatibility

## Test plan
- [x] Frontmatter parsing works correctly
- [x] Tags display as clickable links
- [x] Tag filtering pages show correct thoughts
- [x] Chronological sorting preserved after adding frontmatter
- [x] All existing functionality preserved
- [x] TypeScript and linting pass