### PR TITLE
feat: add SEO structured data for Person and BlogPosting schemas

### DIFF
--- a/app/lib/structured-data.ts
+++ b/app/lib/structured-data.ts
@@ -1,0 +1,50 @@
+export function generatePersonSchema() {
+	return {
+		'@context': 'https://schema.org',
+		'@type': 'Person',
+		name: 'Tomas Klingen',
+		url: 'https://tomasklingen.github.io',
+		jobTitle: 'Front-end Web Developer',
+		description:
+			'Passionate Front-end Web Developer based in the Netherlands with expertise in React, Angular, TypeScript, and crafting modern, user-centric web applications.',
+		sameAs: [
+			'https://github.com/tomasklingen',
+			'https://linkedin.com/in/tomasklingen',
+		],
+	}
+}
+
+export function generateBlogPostingSchema({
+	title,
+	url,
+	datePublished,
+	dateModified,
+	description,
+}: {
+	title: string
+	url: string
+	datePublished: string
+	dateModified?: string
+	description?: string
+}) {
+	return {
+		'@context': 'https://schema.org',
+		'@type': 'BlogPosting',
+		headline: title,
+		url,
+		datePublished,
+		...(dateModified && { dateModified }),
+		...(description && { description }),
+		author: 'https://tomasklingen.github.io',
+		mainEntityOfPage: {
+			'@type': 'WebPage',
+			'@id': url,
+		},
+	}
+}
+
+export function generateJsonLdMeta(schema: Record<string, unknown>) {
+	return {
+		'script:ld+json': schema,
+	}
+}

--- a/app/routes/_index/route.tsx
+++ b/app/routes/_index/route.tsx
@@ -1,4 +1,5 @@
 import type { MetaFunction } from 'react-router'
+import { generateJsonLdMeta, generatePersonSchema } from '~/lib/structured-data'
 import { getAllThoughts } from '~/lib/thoughts'
 import avatar from '~/resources/img/avatar.avif'
 import type { Route } from './+types/route'
@@ -24,6 +25,7 @@ export const meta: MetaFunction = () => {
 			property: 'og:image',
 			content: avatar,
 		},
+		generateJsonLdMeta(generatePersonSchema()),
 	]
 }
 

--- a/app/routes/thoughts.$year.$slug/route.tsx
+++ b/app/routes/thoughts.$year.$slug/route.tsx
@@ -1,6 +1,10 @@
 import { PrecompiledMDXContent } from '~/components/PrecompiledMDXContent'
 import { Tags } from '~/components/Tags'
 import { formatDate } from '~/lib/date'
+import {
+	generateBlogPostingSchema,
+	generateJsonLdMeta,
+} from '~/lib/structured-data'
 import { getAllThoughts } from '~/lib/thoughts'
 import type { Route } from './+types/route'
 
@@ -11,12 +15,20 @@ export function meta({ data }: Route.MetaArgs) {
 		return [{ title: '404 - Thought Not Found | Tomas Klingen' }]
 	}
 
+	const blogPostingSchema = generateBlogPostingSchema({
+		title: data.title,
+		url: `https://tomasklingen.github.io/thoughts/${data.year}/${data.slug}`,
+		datePublished: data.dateCreated.toISOString(),
+		description: `A collection of insights and learnings on ${data.title}.`,
+	})
+
 	return [
 		{ title: `${data.title} | Thoughts | Tomas Klingen` },
 		{
 			name: 'description',
 			content: `A collection of insights and learnings on ${data.title}.`,
 		},
+		generateJsonLdMeta(blogPostingSchema),
 	]
 }
 


### PR DESCRIPTION
## Summary
- Add Person schema to homepage with author information and social links
- Add BlogPosting schema to individual thought pages with metadata
- Use clean URL reference for BlogPosting author instead of inline object duplication
- Implement proper JSON-LD formatting for search engine optimization

## Implementation Details
- Created `app/lib/structured-data.ts` with utility functions for generating schemas
- Added Person schema to homepage via index route meta function
- Added BlogPosting schema to thought pages with title, URL, publish date, and description
- BlogPosting author references Person schema by URL for cleaner data structure
- Uses React Router's meta function for server-side rendering compatibility

## Test Plan
- [x] Build passes without errors
- [x] Person schema appears correctly on homepage
- [x] BlogPosting schema appears correctly on thought pages
- [x] Author reference uses URL instead of inline object
- [x] JSON-LD validates properly in browser dev tools
- [x] No TypeScript or linting errors

## SEO Benefits
- Enhanced search engine understanding of site structure and authorship
- Improved rich snippets potential in search results
- Better content attribution and author information
- Schema.org compliant structured data for better discoverability